### PR TITLE
Unused package import removed

### DIFF
--- a/v1/service_linux.go
+++ b/v1/service_linux.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"strconv"
 	"text/template"
 )
 


### PR DESCRIPTION
Unused "strconv" package removed from service_linux file

It produces a warning when installing package using `go get github.com/goinggo/service/v1`